### PR TITLE
AutoLoadGame: Modifications to wait before savegame loading

### DIFF
--- a/AutoLoadGame/ModConfig.cs
+++ b/AutoLoadGame/ModConfig.cs
@@ -11,5 +11,7 @@ namespace AutoLoadGame
         public String LastFileLoaded = null;
         public Boolean LoadIntoMultiplayer = false;
         public Boolean ForgetLastFileOnTitle = true;
+        public int TicksBeforeLoadSP = 5;   //ca. 0,084 seconds (assuming 60 FPS)
+        public int TicksBeforeLoadMP = 300; //ca. 5 seconds (assuming 60 FPS)
     }
 }

--- a/AutoLoadGame/ModEntry.cs
+++ b/AutoLoadGame/ModEntry.cs
@@ -9,7 +9,7 @@ namespace AutoLoadGame
 {
     class ModEntry : Mod
     {
-        private int wait = 5;
+        private int wait;
         private ModConfig Config;
 
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
@@ -17,6 +17,11 @@ namespace AutoLoadGame
         public override void Entry(IModHelper helper)
         {
             this.Config = helper.ReadConfig<ModConfig>();
+
+            wait = this.Config.TicksBeforeLoadSP;
+            if (this.Config.LoadIntoMultiplayer)
+                wait = this.Config.TicksBeforeLoadMP;
+
             if (this.Config.LastFileLoaded != null)
                 helper.Events.GameLoop.UpdateTicked += waitUntilReady;
 
@@ -54,7 +59,10 @@ namespace AutoLoadGame
                 // Need to delay so options can load correctly... 
                 if (wait <= 0)
                 {
-                    wait = 5;
+                    wait = this.Config.TicksBeforeLoadSP;
+                    if (this.Config.LoadIntoMultiplayer)
+                        wait = this.Config.TicksBeforeLoadMP;
+
                     Helper.Events.GameLoop.UpdateTicked -= waitUntilReady;
                     doLoad();
                 }
@@ -109,3 +117,4 @@ namespace AutoLoadGame
 
     }
 }
+


### PR DESCRIPTION
- Added option "TicksBeforeLoadSP" (SinglePlayer) and "TicksBeforeLoadMP" (Multiplayer), which can be used to modify waittime. (If game runs with 60 FPS, a value of 60 would mean 1 second waittime)
- Increased default wait time value for multiplayer to 300 (5 sec), because (I guess) the game needs some time to initialize networking. Without this higher waittime, the game will set the loaded game "offline" and will therefor not generate any invitation code.